### PR TITLE
Update product scan and visit logic

### DIFF
--- a/database/operations.py
+++ b/database/operations.py
@@ -219,6 +219,16 @@ def backup():
     print("Saved backup to ", path)
 
 
+def scan_and_update_products():
+    products = _DATABASE.find({"oldprice": 0, "prices.1": {"$exists": True}})
+    for product in products:
+        oldprice = product["prices"][-2]
+        _DATABASE.update_one(
+            {"_id": product["_id"]},
+            {"$set": {"oldprice": oldprice, "discount": 0}}
+        )
+
+
 # Restore remote database with local backup from `date`
 # restore(date = "2024-12-26")
 

--- a/server.js
+++ b/server.js
@@ -347,7 +347,10 @@ snublejuice.get("/", authenticate, async (req, res) => {
   if (subdomain === "landing") {
     return res.render("landing", {
       user: user,
-      visitors: meta.visitors.fresh.month[month],
+      visitors: {
+        vinmonopolet: meta.visitors.fresh.month[month].vinmonopolet || 0,
+        taxfree: meta.visitors.fresh.month[month].taxfree || 0,
+      },
     });
   }
 


### PR DESCRIPTION
Add a function to scan and update products in the database and update server logic for visitor data.

* **database/operations.py**
  - Add `scan_and_update_products` function to scan products with `oldprice=0` and `prices.length>=2`.
  - Update `oldprice` to the second last price and set `discount` to 0 for matching products.

* **server.js**
  - Update logic to check `meta.visitors.fresh.month[month]` for `vinmonopolet` and `taxfree`.
  - Set `vinmonopolet` and `taxfree` to 0 if they do not exist.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hallvardnmbu/snublejuice/pull/38?shareId=c9856042-1ad4-4b24-b046-c63eceed79fe).